### PR TITLE
format stdout output

### DIFF
--- a/src/lib/args.rs
+++ b/src/lib/args.rs
@@ -17,6 +17,7 @@ pub fn parse(opts: &getopts::Options, args: &[String]) -> Result<SgfRenderArgs, 
     }
     let infile = matches.free.first().map(PathBuf::from);
     let outfile = matches.opt_str("o").map(PathBuf::from);
+    let format = matches.opt_str("f");
     let print_help = matches.opt_present("h");
     let print_version = matches.opt_present("version");
     let options = extract_make_svg_options(&matches)?;
@@ -24,6 +25,7 @@ pub fn parse(opts: &getopts::Options, args: &[String]) -> Result<SgfRenderArgs, 
     Ok(SgfRenderArgs {
         infile,
         outfile,
+        format,
         options,
         print_version,
         print_help,
@@ -151,6 +153,12 @@ pub fn build_opts() -> getopts::Options {
         "FILE",
     );
     opts.optopt(
+	"f",
+	"format",
+	"Format for stdout, SVG and PNG formats supported.",
+	"FORMAT",
+    );
+    opts.optopt(
         "n",
         "node",
         &format!(
@@ -231,6 +239,7 @@ pub fn build_opts() -> getopts::Options {
 pub struct SgfRenderArgs {
     pub infile: Option<PathBuf>,
     pub outfile: Option<PathBuf>,
+    pub format: Option<String>,
     pub options: MakeSvgOptions,
     pub print_version: bool,
     pub print_help: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod lib;
 use minidom::Element;
 use std::error::Error;
 use std::path::Path;
+use std::io::{self, Write};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -44,7 +45,7 @@ fn main() {
         }
     };
 
-    if let Err(e) = write_output(&svg, parsed_args.outfile) {
+    if let Err(e) = write_output(&svg, parsed_args.outfile, parsed_args.format) {
         eprintln!("Failed to write output: {}", e);
         std::process::exit(1);
     }
@@ -60,10 +61,37 @@ fn read_input<P: AsRef<Path>>(infile: Option<P>) -> Result<String, Box<dyn Error
     Ok(input)
 }
 
-fn write_output<P: AsRef<Path>>(svg: &Element, outfile: Option<P>) -> Result<(), Box<dyn Error>> {
+fn write_output<P: AsRef<Path>>(svg: &Element, outfile: Option<P>, format: Option<String>) -> Result<(), Box<dyn Error>> {
     match outfile {
         Some(filename) => write_to_file(filename.as_ref(), svg)?,
-        None => svg.write_to(&mut std::io::stdout())?,
+        None => {
+            match format {
+                Some(filetype) => {
+                    let mut buffer: Vec<u8> = vec![];
+                    svg.write_to(&mut buffer)?;
+                    let s = std::str::from_utf8(&buffer)?;
+                    let mut fontdb = usvg::fontdb::Database::new();
+                    let font_data = include_bytes!("../resources/Roboto-Bold.ttf").to_vec();
+                    fontdb.load_font_data(font_data);
+                    let tree = usvg::Tree::from_str(
+                    s,
+                    &usvg::Options {
+                        fontdb,
+                        ..usvg::Options::default()
+                    },
+                    )?;
+                    let pixmap_size = tree.svg_node().size.to_screen_size();
+                    let mut pixmap = tiny_skia::Pixmap::new(pixmap_size.width(), pixmap_size.height()).unwrap();
+                    resvg::render(&tree, usvg::FitTo::Original, pixmap.as_mut())
+                        .ok_or(SgfRenderError::PNGRenderFailed)?;
+
+                    io::stdout().write_all(&pixmap.encode_png().unwrap())?;
+                },
+                None => svg.write_to(&mut std::io::stdout())?
+
+            }
+
+        },
     }
     Ok(())
 }


### PR DESCRIPTION
Allow stdout output to be formatted to either svg or png, to help with using this program for scripting (where a png image output is desirable). 

I need to move the create png logic to it's own function so it's not duplicated, as well as actually check the format string. Right now if any format is specified it outputs png, if none is specified it outputs svg

This is a preliminary PR. I'm pretty new to Rust, and I know this needs to cleaned up quite a bit. But, for the moment it does what I need. 